### PR TITLE
add DocExpansion and OAuth config properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,15 @@ func main() {
 	app.Get("/swagger/*", swagger.New(swagger.Config{ // custom
 		URL: "http://example.com/doc.json",
 		DeepLinking: false,
+		// Expand ("list") or Collapse ("none") tag groups by default
+		DocExpansion: "none",
+		// Prefill OAuth ClientId on Authorize popup
+		OAuth: &swagger.OAuthConfig{
+			AppName:  "OAuth Provider",
+			ClientId: "21bb4edc-05a7-4afc-86f1-2e151e4ba6e2",
+		},
+		// Ability to change OAuth2 redirect uri location
+		OAuth2RedirectUrl: "http://localhost:8080/swagger/oauth2-redirect.html",
 	}))
 
 	app.Listen(":8080")

--- a/index.go
+++ b/index.go
@@ -73,9 +73,21 @@ window.onload = function() {
     plugins: [
       SwaggerUIBundle.plugins.DownloadUrl
     ],
-	layout: "StandaloneLayout",
-	deepLinking: {{.DeepLinking}}
+    layout: "StandaloneLayout",
+    deepLinking: {{.DeepLinking}},
+    docExpansion: "{{.DocExpansion}}",
+    {{if .OAuth2RedirectUrl}}
+    oauth2RedirectUrl: {{.OAuth2RedirectUrl}},
+    {{end}}
   })
+
+  {{if .OAuth}}
+  ui.initOAuth({
+    appName: "{{.OAuth.AppName}}",
+    clientId: "{{.OAuth.ClientId}}"
+  })
+  {{end}}
+
   window.ui = ui
 }
 </script>

--- a/main.go
+++ b/main.go
@@ -21,16 +21,40 @@ const (
 // Handler default
 var Handler = New()
 
-// Config ...
+// Config stores SwaggerUI configuration variables
 type Config struct {
+	// Enable deep linking for tags and operations, default is true
 	DeepLinking bool
-	URL         string
+
+	// Controls the default expansion setting for the operations and tags.
+	// 'list' (default, expands only the tags),
+	// 'full' (expands the tags and operations),
+	// 'none' (expands nothing)
+	DocExpansion string
+
+	// Configuration information for OAuth2, optional if using OAuth2
+	OAuth *OAuthConfig
+
+	// Custom OAuth redirect URL
+	OAuth2RedirectUrl string
+
+	// URL pointing to API definition
+	URL string
+}
+
+type OAuthConfig struct {
+	// application name, displayed in authorization popup
+	AppName string
+
+	// ID of the client sent to the OAuth2 Provider, default is clientId
+	ClientId string
 }
 
 // New returns custom handler
 func New(config ...Config) fiber.Handler {
 	cfg := Config{
-		DeepLinking: true,
+		DeepLinking:  true,
+		DocExpansion: "list",
 	}
 
 	if len(config) > 0 {


### PR DESCRIPTION
Added configuration variables for the following:

DocExpansion - controls whether the tag groups are expanded or collapsed by default

OAuth - adds ability to prefill the oauth clientId and app name in the Authorize popup dialog

OAuth2RedirectUrl - adds ability to change the default oauth2 redirect url for cases where its hosted on a different path like "/swagger"